### PR TITLE
Fix tray app PATH resolution and script stdin for curl|bash

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -155,7 +155,7 @@ ENV_FILE="$INSTALL_DIR/.env"
 
 if [ -f "$ENV_FILE" ]; then
     info "Existing .env found"
-    read -rp "Overwrite existing config? [y/N] " OVERWRITE
+    read -rp "Overwrite existing config? [y/N] " OVERWRITE < /dev/tty
     if [[ ! "$OVERWRITE" =~ ^[Yy]$ ]]; then
         ok "Keeping existing .env"
         SKIP_ENV=true
@@ -171,8 +171,8 @@ if [ "$SKIP_ENV" = false ]; then
     info "Configure your AI Assistant:"
     echo ""
 
-    read -rp "  Telegram Bot Token: " TELEGRAM_BOT_TOKEN
-    read -rp "  Telegram Allowed User IDs (comma-separated): " TELEGRAM_ALLOWED_USERS
+    read -rp "  Telegram Bot Token: " TELEGRAM_BOT_TOKEN < /dev/tty
+    read -rp "  Telegram Allowed User IDs (comma-separated): " TELEGRAM_ALLOWED_USERS < /dev/tty
 
     # ─── Step 6: Write .env ──────────────────────────────────────────────────
 
@@ -273,7 +273,7 @@ echo ""
 
 # ─── Step 10: Launch agent (start on login) ─────────────────────────────────
 
-read -rp "Start AI Assistant on login? [y/N] " START_ON_LOGIN
+read -rp "Start AI Assistant on login? [y/N] " START_ON_LOGIN < /dev/tty
 
 if [[ "$START_ON_LOGIN" =~ ^[Yy]$ ]]; then
     mkdir -p "$HOME/Library/LaunchAgents"

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -26,7 +26,7 @@ echo -e "${BOLD}🤖 AI Assistant Uninstaller${NC}"
 echo "────────────────────────────────────────"
 echo ""
 
-read -rp "This will remove AI Assistant and all its data. Continue? [y/N] " CONFIRM
+read -rp "This will remove AI Assistant and all its data. Continue? [y/N] " CONFIRM < /dev/tty
 if [[ ! "$CONFIRM" =~ ^[Yy]$ ]]; then
     info "Cancelled."
     exit 0
@@ -70,7 +70,7 @@ fi
 # Remove repo / installation
 if [ -d "$INSTALL_DIR" ]; then
     echo ""
-    read -rp "Also remove the repository and all data at $INSTALL_DIR? [y/N] " REMOVE_REPO
+    read -rp "Also remove the repository and all data at $INSTALL_DIR? [y/N] " REMOVE_REPO < /dev/tty
     if [[ "$REMOVE_REPO" =~ ^[Yy]$ ]]; then
         rm -rf "$INSTALL_DIR"
         ok "Repository removed: $INSTALL_DIR"


### PR DESCRIPTION
## Summary
- **Tray app**: GUI apps launched via `open` or LaunchAgent only get minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`), so the gateway couldn't find `claude`, `whisper-cli`, or `ffmpeg`. Now resolves the user's full shell PATH in `loadEnv()` by invoking their login shell.
- **Install/uninstall scripts**: `read` calls hang when piped from `curl | bash` because stdin is consumed by the pipe. Fixed all `read` calls to read from `/dev/tty`.

## Test plan
- [ ] Compile tray app: `swiftc -O -o tools/tray-app/ai-assistant-tray tools/tray-app/main.swift -framework Cocoa`
- [ ] Launch tray app via `open` and verify server can find `claude` (send a test message)
- [ ] Test uninstall: `curl -fsSL .../uninstall.sh | bash` — prompts should accept input
- [ ] Test install: `curl -fsSL .../install.sh | bash` — prompts should accept input

🤖 Generated with [Claude Code](https://claude.com/claude-code)