### PR TITLE
Fix release workflow: lowercase Docker image name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   release:
@@ -20,6 +19,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set image name
+        id: image
+        run: echo "name=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
       - name: Read VERSION
         id: version
@@ -47,8 +50,8 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:latest
           build-args: |
             APP_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary
- Fix `release.yml` to lowercase the repository name for Docker tags
- `github.repository` returns `SaschaHenning/ai-assistant` (mixed case), but GHCR requires lowercase
- Uses bash `${GITHUB_REPOSITORY,,}` expansion to ensure valid tags

Fixes the failed release run: https://github.com/SaschaHenning/ai-assistant/actions/runs/22130040850

🤖 Generated with [Claude Code](https://claude.com/claude-code)